### PR TITLE
OldCRT.glsl fix only top left quadrant drawn.

### DIFF
--- a/Artistic/OldCRT.glsl
+++ b/Artistic/OldCRT.glsl
@@ -63,7 +63,7 @@ vec4 darken_color(vec4 color, vec2 coords)
     }
 
     // Get how far the coords are from the center
-    vec2 distances_from_center = window_center - coords;
+    vec2 distances_from_center = abs(window_center - coords);
 
     // Darken pixels close to the edges of the screen in a polynomial fashion
     float brightness = 1;


### PR DESCRIPTION
distances_from_center was becoming negative and turning all colors black aside the top left quadrant.

![noabs](https://user-images.githubusercontent.com/5022760/236534657-045b20b6-bd4b-4bc3-b51e-ced9a7c134e1.png)

![abs](https://user-images.githubusercontent.com/5022760/236534700-8e0f08da-c245-43eb-a248-4168afb9e45f.png)
